### PR TITLE
Opening Places from a deep link

### DIFF
--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.h
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.h
@@ -48,6 +48,8 @@ extern NSString *const WMFNavigateToActivityNotification;
 
 - (NSURL *)wmf_contentURL;
 
+- (NSString *)wmf_placesAppCoordinates;
+
 + (NSURL *)wmf_baseURLForActivityOfType:(WMFUserActivityType)type;
 
 + (NSURL *)wmf_URLForActivityOfType:(WMFUserActivityType)type withArticleURL:(NSURL *)articleURL;

--- a/Wikipedia/Code/NSUserActivity+WMFExtensions.m
+++ b/Wikipedia/Code/NSUserActivity+WMFExtensions.m
@@ -228,6 +228,8 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
         }
     } else if ([self wmf_contentURL]) {
         return WMFUserActivityTypeContent;
+    } else if ([self wmf_placesAppCoordinates]) {
+        return WMFUserActivityTypePlaces;
     } else if ([self.activityType isEqualToString:CSQueryContinuationActionType]) {
         return WMFUserActivityTypeSearchResults;
     } else {
@@ -266,6 +268,25 @@ __attribute__((annotate("returns_localized_nsstring"))) static inline NSString *
 
 - (NSURL *)wmf_contentURL {
     return self.userInfo[@"WMFURL"];
+}
+
+// Sting in format "<lat> <lon>"
+- (NSString *)wmf_placesAppCoordinates {
+    NSURLComponents *components = [[NSURLComponents alloc] initWithURL:self.webpageURL resolvingAgainstBaseURL:YES];
+    if (![components.path hasSuffix:@"/placesApp"]) {
+        return nil;
+    }
+    NSNumber *latitude, *longitude;
+    for (NSURLQueryItem *item in components.queryItems) {
+        if ([item.name isEqualToString:@"lat"]) {
+            latitude = [NSNumber numberWithDouble:[item.value doubleValue]];
+        }
+        if ([item.name isEqualToString:@"lon"]) {
+            longitude = [NSNumber numberWithDouble:[item.value doubleValue]];
+        }
+    }
+    
+    return  [NSString stringWithFormat:@"%@ %@", latitude.stringValue, longitude.stringValue];;
 }
 
 + (NSURLComponents *)wmf_baseURLComponentsForActivityOfType:(WMFUserActivityType)type {

--- a/Wikipedia/Code/SceneDelegate.swift
+++ b/Wikipedia/Code/SceneDelegate.swift
@@ -35,6 +35,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         UNUserNotificationCenter.current().delegate = appViewController
         appViewController.launchApp(in: window, waitToResumeApp: appNeedsResume)
+        
+        if let userActivity = connectionOptions.userActivities.first {
+            process(userActivity: userActivity)
+        }
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -67,6 +71,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        process(userActivity: userActivity)
+    }
+    
+    func process(userActivity: NSUserActivity) {
         guard let appViewController else {
             return
         }

--- a/Wikipedia/Code/WMFAppViewController.m
+++ b/Wikipedia/Code/WMFAppViewController.m
@@ -385,7 +385,7 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
 
 - (void)appWillEnterForegroundWithNotification:(NSNotification *)note {
     // Don't access anything that can't be accessed in the background without starting a background task. For example, don't use anything in the shared app container like all of the Core Data persistent stores
-    self.unprocessedUserActivity = nil;
+    //self.unprocessedUserActivity = nil;
     self.unprocessedShortcutItem = nil;
 }
 
@@ -1205,11 +1205,16 @@ NSString *const WMFLanguageVariantAlertsLibraryVersion = @"WMFLanguageVariantAle
             [self dismissPresentedViewControllers];
             [self setSelectedIndex:WMFAppTabTypePlaces];
             [self.currentTabNavigationController popToRootViewControllerAnimated:animated];
-            NSURL *articleURL = activity.wmf_linkURL;
-            if (articleURL) {
+            NSURL *url = activity.wmf_linkURL;
+            if (url) {
                 // For "View on a map" action to succeed, view mode has to be set to map.
                 [[self placesViewController] updateViewModeToMap];
-                [[self placesViewController] showArticleURL:articleURL];
+                NSString *placesAppCoordinates = [activity wmf_placesAppCoordinates];
+                if (placesAppCoordinates) {
+                    [[self placesViewController] showPlacesAppURLWith:placesAppCoordinates];
+                } else {
+                    [[self placesViewController] showArticleURL:url];
+                }
             }
         } break;
         case WMFUserActivityTypeContent: {


### PR DESCRIPTION
# General considerations
- The Wikipedia application craves more attention and care! (too big and not structured classes, absence of separation of concerns, ObjC in paces slows down the development a bit - because of interop with Swift, which is still not so smooth)
- To solve the task we could use URL-scheme or Universal Link for the deep linking. 
	* With the URL scheme it would be more aligned with what was there already (it seems like they still mostly use URL schemes). It also would be a bit easier as they already have the link to open the Places (`wikipedia://places`) so we could just add optional coordinates there.
	* But using URL schemes in general is highly discouraged by Apple, so I decided to use Universal Links (which are more secure and nowadays the industry standard).

### NSUserActivity+WMFExtensions
- According to the existing logic, when parsing a deep link we first need to distinguish a type and then in another place, we can parse the parameters (coordinates). It's not optimal, and could be fixed (it will require some refactoring and lies outside of the scope for this task)
- Passing the data to the view layer: some ugliness for the sake of simplicity. Because of the necessary interop between ObjC and Swift, it's not so trivial to pass coordinates between the layers. We could either 
	* dd a dependency of CoreLocation and use `CLLocationCoordinate2D` in `WMFAppViewController` and NSUserActivity+WMFExtensions (and I believe these high-level objects shouldn't have such dependency)
	* create an object (NSObject subclass) for this data (requires adding a new type to the WMF module's API and `Wikipedia-Bridging-Header.h`, hence looks like an overhead)
	* concatenate and pass the coordinates in the form of a simple interoperable type like String (it has a drawback of encoding/decoding of this string and possible misalignment between them... but it's more simple and maintainable)

### PlacesViewController
- There shouldn't be so much business logic in a view controller. My changes (storing pending location, parsing the location-string) should have been done in a view model. However, refactoring this class is outside of the context of this task.

### WMFAppViewController
- Due to the lack of time I didn't properly solve the issue of retaining the activity during the app launch (initializing/loading all the logic and UI) when the app is launched from a deep link. I found this property `unprocessedUserActivity` which seems to be ideal for this case. But for some reason, it's being reset on `appWillEnterForegroundWithNotification`, which happens during the app loading after launch. In a real world i would try to gather some context regarding WHY it was needed and then develop a better way of doing it without breaking the current logic. So I just commented it for now.

